### PR TITLE
Allow for piped functions even if no mask is supplied

### DIFF
--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -19,7 +19,7 @@ export default function createTextMaskInputElement({
   // Text Mask accepts masks that are a combination of a `mask` and a `pipe` that work together. If such a `mask` is
   // passed, we destructure it below, so the rest of the code can work normally as if a separate `mask` and a `pipe`
   // were passed.
-  if (typeof providedMask === strObject && providedMask.pipe !== undefined && providedMask.mask !== undefined) {
+  if (typeof providedMask === strObject && !!providedMask && providedMask.pipe !== undefined && providedMask.mask !== undefined) {
     pipe = providedMask.pipe
     providedMask = providedMask.mask
   }
@@ -48,6 +48,18 @@ export default function createTextMaskInputElement({
     // The caller can send a `rawValue` to be conformed and set on the input element. However, the default use-case
     // is for this to be read from the `inputElement` directly.
     update(rawValue = inputElement.value) {
+      // Custom code to quickly allow for piping even when a mask isn't provided
+      // This is a cheap hack to get what we need working
+      if (providedMask === false && pipe) {
+        const pipedResult = pipe(inputElement.value)
+        if (inputElement.value !== pipedResult) {
+          const carretPos = inputElement.selectionStart
+          inputElement.value = pipedResult // set the input value
+          safeSetSelection(inputElement, carretPos) // adjust caret position
+        }
+
+        return
+      }
       // In framework components that support reactivity, it's possible to turn off masking by passing
       // `false` for `mask` after initialization. See https://github.com/text-mask/text-mask/pull/359
       if (providedMask === false) { return }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-mask-all",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Conforms string to given mask or pattern, and can be hooked up to input element",
   "main": "index.js",
   "babel": {

--- a/react/src/reactTextMask.js
+++ b/react/src/reactTextMask.js
@@ -10,7 +10,7 @@ export const MaskedInput = React.createClass({
         mask: PropTypes.oneOfType([PropTypes.array, PropTypes.func]),
         pipe: PropTypes.func
       })
-    ]).isRequired,
+    ]),
     guide: PropTypes.bool,
     value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     pipe: PropTypes.func,


### PR DESCRIPTION
This pr allows for the pipe function to work, even if no mask is supplied in the options. eg.

This will now work:

```
<MaskedInput
              mask={ false }
              pipe={ (val) => val && val.toLowerCase() }
              className='form-control'
              id='1'
              type='text'
            />
```