### PR TITLE
Fix react warning for bools

### DIFF
--- a/react/src/reactTextMask.js
+++ b/react/src/reactTextMask.js
@@ -4,6 +4,7 @@ import createTextMaskInputElement from '../../core/src/createTextMaskInputElemen
 export const MaskedInput = React.createClass({
   propTypes: {
     mask: PropTypes.oneOfType([
+      PropTypes.bool,
       PropTypes.array,
       PropTypes.func,
       PropTypes.shape({


### PR DESCRIPTION
Sorry, just noticed a prop warning in the console. The core library allows for `false` to be passed as a mask, but the current react component did not.