### PR TITLE
Clear console errors when mask is used on email fields

### DIFF
--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -176,7 +176,9 @@ export default function createTextMaskInputElement({
 }
 
 function safeSetSelection(element, selectionPosition) {
-  if (document.activeElement === element) {
+  if (document.activeElement === element &&
+      // setSelectionRange does not work for input fields like `email`.
+      /text|password|search|tel|url/.test(element.type)) {
     setTimeout(() => {
       element.setSelectionRange(selectionPosition, selectionPosition, strNone)
     }, 0);

--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -178,6 +178,9 @@ export default function createTextMaskInputElement({
 function safeSetSelection(element, selectionPosition) {
   if (document.activeElement === element &&
       // setSelectionRange does not work for input fields like `email`.
+      // This conditional is only to remove the many error messages that are
+      // showing up in the console. It is not a final solution, and should
+      // eventually be removed.
       /text|password|search|tel|url/.test(element.type)) {
     setTimeout(() => {
       element.setSelectionRange(selectionPosition, selectionPosition, strNone)


### PR DESCRIPTION
This is a temporary fix only. We're getting the following error in our console:

```
Uncaught DOMException: Failed to execute 'setSelectionRange' on 'HTMLInputElement': The input element's type ('email') does not support selection.
    at eval (eval at <anonymous>
```

This is because text selection is not available on email fields (or number fields even). What we need to do is remove input masking altogether, but I've created a separate ticket for that. Once that's done, this pr can be reverted.