### PR TITLE
Removes defaultValue. binds props.value to input value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-# [![Text Mask](assets/logo.png)](https://github.com/text-mask/text-mask/#readme)
+# Text Mask (UNOFFICIAL FORK!)
 
-[![Build Status](https://travis-ci.org/text-mask/text-mask.svg?branch=master)](https://travis-ci.org/text-mask/text-mask)
+## DO NOT USE!
+This is an unmaintained fork to "fix" an issue with caret positioning on Android.
 
+https://github.com/text-mask/text-mask/issues/300
+
+This will be deleted when the main library is "fixed", so, don't rely on it being here unless you're the person that put it here.
+
+## Text Mask
 Text Mask is an input mask library. It can create input masks for phone, date, currency, zip code, percentage, email, 
 and literally anything!
 

--- a/core/src/createTextMaskInputElement.js
+++ b/core/src/createTextMaskInputElement.js
@@ -165,7 +165,9 @@ export default function createTextMaskInputElement({
 
 function safeSetSelection(element, selectionPosition) {
   if (document.activeElement === element) {
-    element.setSelectionRange(selectionPosition, selectionPosition, strNone)
+    setTimeout(() => {
+      element.setSelectionRange(selectionPosition, selectionPosition, strNone)
+    }, 0);
   }
 }
 

--- a/publish.sh
+++ b/publish.sh
@@ -9,4 +9,4 @@ fi
 
 generatedNpmVersion="$(npm version $version)"
 
-npm publish --access public --tag "text-mask-${generatedNpmVersion}"
+npm publish --access public --tag "mhazy-text-mask-${generatedNpmVersion}"

--- a/react/package.json
+++ b/react/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-text-mask",
+  "name": "mhazy-react-text-mask",
   "version": "1.0.0",
-  "description": "React input component that accepts mask pattern",
+  "description": "React input component that accepts mask pattern (BUG FIX EDITION)",
   "main": "dist/reactTextMask.js",
   "author": "M.K. Safi <msafi@msafi.com>",
   "license": "Unlicense",


### PR DESCRIPTION
This addresses a specific issue in which the state was changing (without an `onChange` handler i.e.  from a saga) and the value of the input field was not being updated.

`defaultValue` and `value` cannot be used together (results in a warning from React). In addition, it seems that React suggests not using `defaultValue` if you need a controlled component: https://facebook.github.io/react/docs/uncontrolled-components.html#default-values 

~This will need to be merged in tandem with a PR i'm issuing from our Front-End repo.~

I'm not sure there will be repercussions, but everything seems to be functioning normally locally after the change.